### PR TITLE
change android support library version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:palette-v7:+'
+    compile 'com.android.support:palette-v7:23.0.1'
     compile 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
android support library need to use same version with root project, or it will getting error when compiled with different version